### PR TITLE
Implement reconstruction scaffold with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,21 @@ These are quality, operational, and usability requirements that the system must 
 | Quality Scoring                         | All outputs              | Quality score                         |
 | Final Output                            | Reconstructed + text     | Ready-to-use content                  |
 
+
+## Running the Example
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+sudo apt-get update && sudo apt-get install -y tesseract-ocr
+```
+
+Run the pipeline on a video file:
+
+```bash
+python main.py input.mp4 output.jpg
+```
+
+The reconstructed image will be saved to `output.jpg` and extracted text and quality score will be printed to the console.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+import argparse
+import cv2
+from text_frame_extractor import process_video
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process video and reconstruct text region")
+    parser.add_argument("input_video", help="Path to input video")
+    parser.add_argument("output_image", help="Path to save reconstructed image")
+    args = parser.parse_args()
+
+    image, text, score = process_video(args.input_video)
+    cv2.imwrite(args.output_image, image)
+    print("Extracted Text:\n", text)
+    print("Quality Score:", score)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python
+numpy
+pillow
+pytesseract

--- a/tests/test_frame_selection.py
+++ b/tests/test_frame_selection.py
@@ -1,0 +1,14 @@
+import cv2
+import numpy as np
+from text_frame_extractor.frame_selection import FrameSelector
+
+def test_frame_selection():
+    sharp = np.zeros((20, 20, 3), dtype=np.uint8)
+    cv2.putText(sharp, "A", (2, 15), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 1)
+    blurry = cv2.GaussianBlur(sharp, (5, 5), 3)
+    frames = [blurry, sharp, blurry]
+    selector = FrameSelector(top_n=1)
+    selected = selector.select(frames)
+    assert len(selected) == 1
+    # sharpest frame should be selected
+    assert np.array_equal(selected[0], sharp)

--- a/tests/test_page_reconstruction.py
+++ b/tests/test_page_reconstruction.py
@@ -1,0 +1,12 @@
+import numpy as np
+from text_frame_extractor.page_reconstruction import PageReconstructor
+
+def test_page_reconstruction_average():
+    frame1 = np.zeros((10, 10, 3), dtype=np.uint8)
+    frame1[:, :, 0] = 255
+    frame2 = np.zeros((10, 10, 3), dtype=np.uint8)
+    frame2[:, :, 2] = 255
+    reconstructor = PageReconstructor()
+    result = reconstructor.reconstruct([frame1, frame2])
+    assert result[0, 0, 0] == 127 or result[0, 0, 0] == 128
+    assert result[0, 0, 2] == 127 or result[0, 0, 2] == 128

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,17 @@
+import numpy as np
+import cv2
+from text_frame_extractor.pipeline import process_frames
+
+
+def create_text_image(text: str) -> np.ndarray:
+    img = np.ones((50, 200, 3), dtype=np.uint8) * 255
+    cv2.putText(img, text, (5, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 0), 2, cv2.LINE_AA)
+    return img
+
+
+def test_pipeline_end_to_end():
+    frames = [create_text_image("Test"), create_text_image("Test")]
+    image, text, score = process_frames(frames)
+    assert isinstance(image, np.ndarray)
+    assert "test" in text.lower()
+    assert score > 0

--- a/tests/test_region_detection.py
+++ b/tests/test_region_detection.py
@@ -1,0 +1,10 @@
+import cv2
+import numpy as np
+from text_frame_extractor.region_detection import RegionDetector
+
+def test_region_detection():
+    detector = RegionDetector()
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    cv2.rectangle(frame, (10, 20), (90, 80), (255, 255, 255), -1)
+    bbox = detector.detect(frame)
+    assert bbox == (10, 20, 81, 61)

--- a/text_frame_extractor/__init__.py
+++ b/text_frame_extractor/__init__.py
@@ -1,0 +1,3 @@
+"""Text frame extraction and reconstruction module."""
+from .pipeline import process_frames, process_video
+__all__ = ["process_frames", "process_video"]

--- a/text_frame_extractor/alignment.py
+++ b/text_frame_extractor/alignment.py
@@ -1,0 +1,14 @@
+import cv2
+import numpy as np
+
+class FrameAligner:
+    """Align frames to a reference."""
+    def __init__(self, output_size=None):
+        self.output_size = output_size
+
+    def align(self, frame, bbox):
+        x, y, w, h = bbox
+        cropped = frame[y : y + h, x : x + w]
+        if self.output_size is not None:
+            cropped = cv2.resize(cropped, self.output_size)
+        return cropped

--- a/text_frame_extractor/frame_selection.py
+++ b/text_frame_extractor/frame_selection.py
@@ -1,0 +1,21 @@
+import cv2
+import numpy as np
+
+class FrameSelector:
+    """Select frames based on simple heuristics."""
+
+    def __init__(self, top_n: int = 5):
+        self.top_n = top_n
+
+    def select(self, frames):
+        """Return the top-N sharpest frames."""
+        if len(frames) <= self.top_n:
+            return frames
+
+        scores = []
+        for frame in frames:
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            variance = cv2.Laplacian(gray, cv2.CV_64F).var()
+            scores.append(variance)
+        indices = np.argsort(scores)[::-1][: self.top_n]
+        return [frames[i] for i in indices]

--- a/text_frame_extractor/occlusion_masking.py
+++ b/text_frame_extractor/occlusion_masking.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+class OcclusionMasker:
+    """Return a mask of valid pixels. Currently assume all pixels are valid."""
+
+    def mask(self, frame):
+        """Placeholder that marks all pixels valid."""
+        return np.ones(frame.shape[:2], dtype=np.uint8) * 255

--- a/text_frame_extractor/ocr.py
+++ b/text_frame_extractor/ocr.py
@@ -1,0 +1,10 @@
+from PIL import Image
+import pytesseract
+import numpy as np
+
+class OCR:
+    """Perform OCR on an image using Tesseract."""
+
+    def extract_text(self, image: np.ndarray) -> str:
+        pil_image = Image.fromarray(image)
+        return pytesseract.image_to_string(pil_image)

--- a/text_frame_extractor/page_reconstruction.py
+++ b/text_frame_extractor/page_reconstruction.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+class PageReconstructor:
+    """Combine aligned frames into a single image by averaging."""
+
+    def reconstruct(self, frames, masks=None):
+        if not frames:
+            raise ValueError("No frames provided")
+        accum = np.zeros_like(frames[0], dtype=np.float32)
+        count = np.zeros(frames[0].shape[:2], dtype=np.float32)
+        for idx, frame in enumerate(frames):
+            mask = np.ones(frame.shape[:2], dtype=np.float32)
+            if masks is not None:
+                mask = masks[idx].astype(np.float32) / 255.0
+            for c in range(frame.shape[2]):
+                accum[:, :, c] += frame[:, :, c] * mask
+            count += mask
+        count[count == 0] = 1.0
+        result = (accum / count[..., None]).astype(np.uint8)
+        return result

--- a/text_frame_extractor/pipeline.py
+++ b/text_frame_extractor/pipeline.py
@@ -1,0 +1,53 @@
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+from .frame_selection import FrameSelector
+from .region_detection import RegionDetector
+from .alignment import FrameAligner
+from .occlusion_masking import OcclusionMasker
+from .page_reconstruction import PageReconstructor
+from .ocr import OCR
+from .text_structure import TextStructureAnalyzer
+from .quality_scoring import QualityScorer
+
+
+def process_frames(frames: List[np.ndarray]) -> Tuple[np.ndarray, str, float]:
+    """Process frames and return reconstructed image, text, and quality score."""
+    selector = FrameSelector()
+    detector = RegionDetector()
+    aligner = FrameAligner()
+    masker = OcclusionMasker()
+    reconstructor = PageReconstructor()
+    ocr = OCR()
+    analyzer = TextStructureAnalyzer()
+    scorer = QualityScorer()
+
+    selected = selector.select(frames)
+    aligned_frames = []
+    masks = []
+    for frame in selected:
+        bbox = detector.detect(frame)
+        aligned = aligner.align(frame, bbox)
+        mask = masker.mask(aligned)
+        aligned_frames.append(aligned)
+        masks.append(mask)
+
+    reconstructed = reconstructor.reconstruct(aligned_frames, masks)
+    text = ocr.extract_text(reconstructed)
+    structured_text = analyzer.analyze(text)
+    score = scorer.score(reconstructed)
+    return reconstructed, structured_text, score
+
+
+def process_video(video_path: str) -> Tuple[np.ndarray, str, float]:
+    """Load frames from video and process them."""
+    cap = cv2.VideoCapture(video_path)
+    frames = []
+    success, frame = cap.read()
+    while success:
+        frames.append(frame)
+        success, frame = cap.read()
+    cap.release()
+    return process_frames(frames)

--- a/text_frame_extractor/quality_scoring.py
+++ b/text_frame_extractor/quality_scoring.py
@@ -1,0 +1,10 @@
+import cv2
+
+
+class QualityScorer:
+    """Compute a simple quality score based on sharpness."""
+
+    def score(self, image) -> float:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        var = cv2.Laplacian(gray, cv2.CV_64F).var()
+        return float(var)

--- a/text_frame_extractor/region_detection.py
+++ b/text_frame_extractor/region_detection.py
@@ -1,0 +1,17 @@
+import cv2
+import numpy as np
+
+class RegionDetector:
+    """Detect target reading region."""
+
+    def detect(self, frame):
+        """Detect the main document region in the frame."""
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        _, thresh = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+        contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            height, width = frame.shape[:2]
+            return (0, 0, width, height)
+        largest = max(contours, key=cv2.contourArea)
+        x, y, w, h = cv2.boundingRect(largest)
+        return (x, y, w, h)

--- a/text_frame_extractor/text_structure.py
+++ b/text_frame_extractor/text_structure.py
@@ -1,0 +1,6 @@
+class TextStructureAnalyzer:
+    """Very small text structure analyzer that splits into lines."""
+
+    def analyze(self, text: str) -> str:
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary
- implement lightweight page reconstruction pipeline
- add CLI `main.py` to run the pipeline on a video
- provide package modules for frame selection, region detection, alignment, occlusion masking, reconstruction, OCR, text structure, and quality scoring
- document usage in README
- configure pytest and add unit tests
- implement functional pipeline components

## Testing
- `pip install -r requirements.txt`
- `sudo apt-get update && sudo apt-get install -y tesseract-ocr`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a249958248322a614698a0ef60196